### PR TITLE
bugfix: install python3-libselinux by default on Fedora

### DIFF
--- a/Fedora-35/scripts/ansible.sh
+++ b/Fedora-35/scripts/ansible.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -eux
-dnf -y install ansible rsync curl
+dnf -y install ansible rsync curl python3-libselinux

--- a/spec/packages_spec.rb
+++ b/spec/packages_spec.rb
@@ -39,6 +39,10 @@ when "openbsd"
       its(:stdout) { should eq "" }
     end
   end
+when "fedora"
+  describe package "python3-libselinux" do
+    it { should be_installed }
+  end
 end
 
 describe command "python3 --version" do


### PR DESCRIPTION
almost all roles do not work without it