### PR TITLE
ci: update GitHub Actions runner to macos-12

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -23,7 +23,7 @@ jobs:
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
   packer:
-    runs-on: macos-10.15
+    runs-on: macos-12
     needs:
       - pre_build
     if: ${{ (needs.pre_build.outputs.should_skip != 'true') || (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'schedule') }}

--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -38,7 +38,6 @@ jobs:
           - FreeBSD-12.3
           - OpenBSD-7.1
           - OpenBSD-7.0
-          - OpenBSD-6.9
           - Ubuntu-20.04
           - Devuan-3
           - Devuan-4

--- a/Debian-11/box.pkr.hcl
+++ b/Debian-11/box.pkr.hcl
@@ -11,11 +11,11 @@ variable "mirror" {
 # OS versions and ISO file
 locals {
   version_major     = "11"
-  version_minor     = "3"
+  version_minor     = "4"
   version_patch     = "0"
   code_name         = "bullseye"
   iso_checksum_type = "sha256"
-  iso_checksum      = "7892981e1da216e79fb3a1536ce5ebab157afdd20048fe458f2ae34fbc26c19b"
+  iso_checksum      = "d490a35d36030592839f24e468a5b818c919943967012037d6ab3d65d030ef7f"
   # https://cdimage.debian.org/cdimage/release/11.3.0/amd64/iso-cd/debian-11.3.0-amd64-netinst.iso
   iso_url           = "${var.mirror}/${local.version_major}.${local.version_minor}.${local.version_patch}/amd64/iso-cd/debian-${local.version_major}.${local.version_minor}.${local.version_patch}-amd64-netinst.iso"
 }

--- a/FreeBSD-12.3/scripts/init.sh
+++ b/FreeBSD-12.3/scripts/init.sh
@@ -13,7 +13,7 @@ ${fwcmd} check-state
 ${fwcmd} add 65000 pass all from any to any keep-state
 EOF
 
-sudo pkg install -y lang/python3 py38-ansible rsync
+sudo pkg install -y lang/python3 py39-ansible rsync
 
 # when the release EoLed, or no update is available, freebsd-update exits with
 # non-zero status.

--- a/FreeBSD-13.0/scripts/init.sh
+++ b/FreeBSD-13.0/scripts/init.sh
@@ -13,7 +13,7 @@ ${fwcmd} check-state
 ${fwcmd} add 65000 pass all from any to any keep-state
 EOF
 
-sudo pkg install -y lang/python3 py38-ansible rsync
+sudo pkg install -y lang/python3 py39-ansible rsync
 
 # when the release EoLed, or no update is available, freebsd-update exits with
 # non-zero status.


### PR DESCRIPTION
virtualbox is now working on macos-12.

> It turned out that macOS-12 doesn't have this issue

https://github.com/actions/virtual-environments/pull/5594